### PR TITLE
Add Bitcoin ABC 0.19.1

### DIFF
--- a/abc/0.19.1/Dockerfile
+++ b/abc/0.19.1/Dockerfile
@@ -1,0 +1,39 @@
+FROM debian:stretch-slim
+
+RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV BITCOIN_VERSION 0.19.1
+ENV BITCOIN_URL https://download.bitcoinabc.org/0.19.1/linux/bitcoin-abc-0.19.1-x86_64-linux-gnu.tar.gz
+ENV BITCOIN_SHA256 ffea0367af81fdc2f50e780938c6a1619aec1be125134777fff8a024b56923d1
+ENV BITCOIN_ASC_URL https://download.bitcoinabc.org/0.19.1/jasonbcox-sha256sums.0.19.1.asc
+ENV BITCOIN_PGP_KEY 3BB16D00D9A6D281591BDC76E4486356E7A81D2C
+
+# install bitcoin binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO bitcoin.tar.gz "$BITCOIN_URL" \
+	&& echo "$BITCOIN_SHA256 bitcoin.tar.gz" | sha256sum -c - \
+	&& gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$BITCOIN_PGP_KEY" \
+	&& wget -qO bitcoin.asc "$BITCOIN_ASC_URL" \
+	&& gpg --verify bitcoin.asc \
+	&& tar -xzvf bitcoin.tar.gz -C /usr/local --strip-components=1 --exclude=*-qt \
+	&& rm -rf /tmp/*
+
+# create data directory
+ENV BITCOIN_DATA /data
+RUN mkdir "$BITCOIN_DATA" \
+	&& chown -R bitcoin:bitcoin "$BITCOIN_DATA" \
+	&& ln -sfn "$BITCOIN_DATA" /home/bitcoin/.bitcoin \
+	&& chown -h bitcoin:bitcoin /home/bitcoin/.bitcoin
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 8332 8333 18332 18333
+CMD ["bitcoind"]

--- a/abc/0.19.1/docker-entrypoint.sh
+++ b/abc/0.19.1/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+if [[ "$1" == "bitcoin-cli" || "$1" == "bitcoin-tx" || "$1" == "bitcoind" || "$1" == "test_bitcoin" ]]; then
+	mkdir -p "$BITCOIN_DATA"
+
+	CONFIG_PREFIX=""
+	if [[ "${BITCOIN_NETWORK}" == "regtest" ]]; then
+		CONFIG_PREFIX=$'regtest=1\n[regtest]'
+	fi
+	if [[ "${BITCOIN_NETWORK}" == "testnet" ]]; then
+		CONFIG_PREFIX=$'testnet=1\n[test]'
+	fi
+	if [[ "${BITCOIN_NETWORK}" == "mainnet" ]]; then
+		CONFIG_PREFIX=$'mainnet=1\n[main]'
+	fi
+
+	cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
+	${CONFIG_PREFIX}
+	printtoconsole=1
+	rpcallowip=::/0
+	${BITCOIN_EXTRA_ARGS}
+	EOF
+	chown bitcoin:bitcoin "$BITCOIN_DATA/bitcoin.conf"
+
+	# ensure correct ownership and linking of data directory
+	# we do not update group ownership here, in case users want to mount
+	# a host directory and still retain access to it
+	chown -R bitcoin "$BITCOIN_DATA"
+	ln -sfn "$BITCOIN_DATA" /home/bitcoin/.bitcoin
+	chown -h bitcoin:bitcoin /home/bitcoin/.bitcoin
+
+	exec gosu bitcoin "$@"
+else
+	exec "$@"
+fi

--- a/versions.yml
+++ b/versions.yml
@@ -88,6 +88,9 @@ abc:
   0.15.0:
     url: https://download.bitcoinabc.org/0.15.0/linux/bitcoin-abc-0.15.0-x86_64-linux-gnu.tar.gz
     sha256: de8ec283d6d3bb15545b39dc07f3207d7502d51dd98cfeac79e8d78462808cfc
+  0.19.1:
+    url: https://download.bitcoinabc.org/0.19.1/linux/bitcoin-abc-0.19.1-x86_64-linux-gnu.tar.gz
+    sha256: ffea0367af81fdc2f50e780938c6a1619aec1be125134777fff8a024b56923d1
 
 btc1:
   1.14.3:


### PR DESCRIPTION
Update to the latest Bitcoin Cash/ABC binaries. The Dockerfile and entrypoint scripts are based off the latest core ones, not the ones generated from the template using `make update`. It may be that the template should be updated at some point so that new versions added are close to the new core version, rather than the old template.