### PR TITLE
Add BCHN 23.0.0 support

### DIFF
--- a/bchn/23.0.0/Dockerfile
+++ b/bchn/23.0.0/Dockerfile
@@ -1,0 +1,34 @@
+FROM debian:stretch-slim
+
+RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV BITCOIN_VERSION 23.0.0
+ENV BITCOIN_URL https://github.com/bitcoin-cash-node/bitcoin-cash-node/releases/download/v23.0.0/bitcoin-cash-node-23.0.0-x86_64-linux-gnu.tar.gz
+ENV BITCOIN_SHA256 474d53ba3dc10cee20da4c1e8d77e31a6b3c54c805f72eab7d705c9211c879bd
+
+# install bitcoin binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO bitcoin.tar.gz "$BITCOIN_URL" \
+	&& echo "$BITCOIN_SHA256 bitcoin.tar.gz" | sha256sum -c - \
+	&& tar -xzvf bitcoin.tar.gz -C /usr/local --strip-components=1 --exclude=*-qt \
+	&& rm -rf /tmp/*
+
+# create data directory
+ENV BITCOIN_DATA /data
+RUN mkdir "$BITCOIN_DATA" \
+	&& chown -R bitcoin:bitcoin "$BITCOIN_DATA" \
+	&& ln -sfn "$BITCOIN_DATA" /home/bitcoin/.bitcoin \
+	&& chown -h bitcoin:bitcoin /home/bitcoin/.bitcoin
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 8332 8333 18332 18333
+CMD ["bitcoind"]

--- a/bchn/23.0.0/docker-entrypoint.sh
+++ b/bchn/23.0.0/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+if [[ "$1" == "bitcoin-cli" || "$1" == "bitcoin-tx" || "$1" == "bitcoind" || "$1" == "test_bitcoin" ]]; then
+	mkdir -p "$BITCOIN_DATA"
+
+	CONFIG_PREFIX=""
+	if [[ "${BITCOIN_NETWORK}" == "regtest" ]]; then
+		CONFIG_PREFIX=$'regtest=1\n[regtest]'
+	fi
+	if [[ "${BITCOIN_NETWORK}" == "testnet" ]]; then
+		CONFIG_PREFIX=$'testnet=1\n[test]'
+	fi
+	if [[ "${BITCOIN_NETWORK}" == "mainnet" ]]; then
+		CONFIG_PREFIX=$'mainnet=1\n[main]'
+	fi
+
+	cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
+	${CONFIG_PREFIX}
+	printtoconsole=1
+	rpcallowip=::/0
+	${BITCOIN_EXTRA_ARGS}
+	EOF
+	chown bitcoin:bitcoin "$BITCOIN_DATA/bitcoin.conf"
+
+	# ensure correct ownership and linking of data directory
+	# we do not update group ownership here, in case users want to mount
+	# a host directory and still retain access to it
+	chown -R bitcoin "$BITCOIN_DATA"
+	ln -sfn "$BITCOIN_DATA" /home/bitcoin/.bitcoin
+	chown -h bitcoin:bitcoin /home/bitcoin/.bitcoin
+
+	exec gosu bitcoin "$@"
+else
+	exec "$@"
+fi


### PR DESCRIPTION
### This PR:
- Adds BCHN 23.0.0 support

### This update is required before **Mai 15, 2021**:
- The last version of BCHN in the repo is still 22.1.0 which will stop working in 18 days (see "warnings" on `getblockchaininfo` output as of today):
   <img width="824" alt="Screenshot 2021-04-27 at 08 45 17" src="https://user-images.githubusercontent.com/285900/116197363-f970f680-a734-11eb-91a8-6acb81eb0d3c.png">
- also warning on the https://bitcoincashnode.org/ website:
  ![Screenshot 2021-04-27 at 08 46 54](https://user-images.githubusercontent.com/285900/116197621-42c14600-a735-11eb-8314-75e46d30893e.png)

