### PR TITLE
Add Bitcoin Core 23.0 and 24.0.1

### DIFF
--- a/core/23.0/Dockerfile
+++ b/core/23.0/Dockerfile
@@ -1,0 +1,40 @@
+FROM debian:stretch-slim
+
+RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV BITCOIN_VERSION 23.0
+ENV BITCOIN_FILE bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz
+ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/
+ENV BITCOIN_SHA256 2cca490c1f2842884a3c5b0606f179f9f937177da4eadd628e3f7fd7e25d26d0
+ENV BITCOIN_ASC_URL https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
+ENV BITCOIN_SHASUM_URL https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS
+
+# install bitcoin binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO "$BITCOIN_FILE" "$BITCOIN_URL$BITCOIN_FILE" \
+	&& echo "$BITCOIN_SHA256 $BITCOIN_FILE" | sha256sum -c - \
+	&& wget -qO SHA256SUMS.asc "$BITCOIN_ASC_URL" \
+	&& wget -qO SHA256SUMS "$BITCOIN_SHASUM_URL" \
+	&& sha256sum --ignore-missing --check SHA256SUMS \
+	&& tar -xzvf "$BITCOIN_FILE" -C /usr/local --strip-components=1 --exclude=*-qt \
+	&& rm -rf /tmp/*
+
+# create data directory
+ENV BITCOIN_DATA /data
+RUN mkdir "$BITCOIN_DATA" \
+	&& chown -R bitcoin:bitcoin "$BITCOIN_DATA" \
+	&& ln -sfn "$BITCOIN_DATA" /home/bitcoin/.bitcoin \
+	&& chown -h bitcoin:bitcoin /home/bitcoin/.bitcoin
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 8332 8333 18332 18333 18443 18444
+CMD ["bitcoind"]

--- a/core/23.0/docker-entrypoint.sh
+++ b/core/23.0/docker-entrypoint.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+
+if [[ "$1" == "bitcoin-cli" || "$1" == "bitcoin-tx" || "$1" == "bitcoind" || "$1" == "test_bitcoin" ]]; then
+	mkdir -p "$BITCOIN_DATA"
+
+	CONFIG_PREFIX=""
+	if [[ "${BITCOIN_NETWORK}" == "regtest" ]]; then
+		CONFIG_PREFIX=$'regtest=1\n[regtest]'
+	elif [[ "${BITCOIN_NETWORK}" == "testnet" ]]; then
+		CONFIG_PREFIX=$'testnet=1\n[test]'
+	elif [[ "${BITCOIN_NETWORK}" == "mainnet" ]]; then
+		CONFIG_PREFIX=$'mainnet=1\n[main]'
+	else 
+		BITCOIN_NETWORK=""
+	fi
+
+	if [[ "$BITCOIN_WALLETDIR" ]] && [[ "$BITCOIN_NETWORK" ]]; then
+		NL=$'\n'
+		WALLETDIR="$BITCOIN_WALLETDIR/${BITCOIN_NETWORK}"
+		WALLETFILE="${WALLETDIR}/wallet.dat"
+		mkdir -p "$WALLETDIR"	
+		chown -R bitcoin:bitcoin "$WALLETDIR"
+		CONFIG_PREFIX="${CONFIG_PREFIX}${NL}walletdir=${WALLETDIR}${NL}"
+		if ! [[ -f "${WALLETFILE}" ]]; then
+		  echo "The wallet does not exists, creating it at ${WALLETDIR}..."
+		  gosu bitcoin bitcoin-wallet "-datadir=${WALLETDIR}" "-wallet=" create
+		fi
+	fi
+	
+	cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
+	${CONFIG_PREFIX}
+	printtoconsole=1
+	rpcallowip=::/0
+	rpcbind=0.0.0.0:8332
+	${BITCOIN_EXTRA_ARGS}
+	EOF
+	chown bitcoin:bitcoin "$BITCOIN_DATA/bitcoin.conf"
+
+	# ensure correct ownership and linking of data directory
+	# we do not update group ownership here, in case users want to mount
+	# a host directory and still retain access to it
+	chown -R bitcoin "$BITCOIN_DATA"
+	ln -sfn "$BITCOIN_DATA" /home/bitcoin/.bitcoin
+	chown -h bitcoin:bitcoin /home/bitcoin/.bitcoin
+
+	exec gosu bitcoin "$@"
+else
+	exec "$@"
+fi

--- a/core/24.0.1/Dockerfile
+++ b/core/24.0.1/Dockerfile
@@ -1,0 +1,40 @@
+FROM debian:stretch-slim
+
+RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV BITCOIN_VERSION 24.0.1
+ENV BITCOIN_FILE bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz
+ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/
+ENV BITCOIN_SHA256 49df6e444515d457ea0b885d66f521f2a26ca92ccf73d5296082e633544253bf
+ENV BITCOIN_ASC_URL https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
+ENV BITCOIN_SHASUM_URL https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS
+
+# install bitcoin binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO "$BITCOIN_FILE" "$BITCOIN_URL$BITCOIN_FILE" \
+	&& echo "$BITCOIN_SHA256 $BITCOIN_FILE" | sha256sum -c - \
+	&& wget -qO SHA256SUMS.asc "$BITCOIN_ASC_URL" \
+	&& wget -qO SHA256SUMS "$BITCOIN_SHASUM_URL" \
+	&& sha256sum --ignore-missing --check SHA256SUMS \
+	&& tar -xzvf "$BITCOIN_FILE" -C /usr/local --strip-components=1 --exclude=*-qt \
+	&& rm -rf /tmp/*
+
+# create data directory
+ENV BITCOIN_DATA /data
+RUN mkdir "$BITCOIN_DATA" \
+	&& chown -R bitcoin:bitcoin "$BITCOIN_DATA" \
+	&& ln -sfn "$BITCOIN_DATA" /home/bitcoin/.bitcoin \
+	&& chown -h bitcoin:bitcoin /home/bitcoin/.bitcoin
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 8332 8333 18332 18333 18443 18444
+CMD ["bitcoind"]

--- a/core/24.0.1/docker-entrypoint.sh
+++ b/core/24.0.1/docker-entrypoint.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+
+if [[ "$1" == "bitcoin-cli" || "$1" == "bitcoin-tx" || "$1" == "bitcoind" || "$1" == "test_bitcoin" ]]; then
+	mkdir -p "$BITCOIN_DATA"
+
+	CONFIG_PREFIX=""
+	if [[ "${BITCOIN_NETWORK}" == "regtest" ]]; then
+		CONFIG_PREFIX=$'regtest=1\n[regtest]'
+	elif [[ "${BITCOIN_NETWORK}" == "testnet" ]]; then
+		CONFIG_PREFIX=$'testnet=1\n[test]'
+	elif [[ "${BITCOIN_NETWORK}" == "mainnet" ]]; then
+		CONFIG_PREFIX=$'mainnet=1\n[main]'
+	else 
+		BITCOIN_NETWORK=""
+	fi
+
+	if [[ "$BITCOIN_WALLETDIR" ]] && [[ "$BITCOIN_NETWORK" ]]; then
+		NL=$'\n'
+		WALLETDIR="$BITCOIN_WALLETDIR/${BITCOIN_NETWORK}"
+		WALLETFILE="${WALLETDIR}/wallet.dat"
+		mkdir -p "$WALLETDIR"	
+		chown -R bitcoin:bitcoin "$WALLETDIR"
+		CONFIG_PREFIX="${CONFIG_PREFIX}${NL}walletdir=${WALLETDIR}${NL}"
+		if ! [[ -f "${WALLETFILE}" ]]; then
+		  echo "The wallet does not exists, creating it at ${WALLETDIR}..."
+		  gosu bitcoin bitcoin-wallet "-datadir=${WALLETDIR}" "-wallet=" create
+		fi
+	fi
+	
+	cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
+	${CONFIG_PREFIX}
+	printtoconsole=1
+	rpcallowip=::/0
+	rpcbind=0.0.0.0:8332
+	${BITCOIN_EXTRA_ARGS}
+	EOF
+	chown bitcoin:bitcoin "$BITCOIN_DATA/bitcoin.conf"
+
+	# ensure correct ownership and linking of data directory
+	# we do not update group ownership here, in case users want to mount
+	# a host directory and still retain access to it
+	chown -R bitcoin "$BITCOIN_DATA"
+	ln -sfn "$BITCOIN_DATA" /home/bitcoin/.bitcoin
+	chown -h bitcoin:bitcoin /home/bitcoin/.bitcoin
+
+	exec gosu bitcoin "$@"
+else
+	exec "$@"
+fi

--- a/core/24.0.1/docker-entrypoint.sh
+++ b/core/24.0.1/docker-entrypoint.sh
@@ -9,9 +9,11 @@ if [[ "$1" == "bitcoin-cli" || "$1" == "bitcoin-tx" || "$1" == "bitcoind" || "$1
 		CONFIG_PREFIX=$'regtest=1\n[regtest]'
 	elif [[ "${BITCOIN_NETWORK}" == "testnet" ]]; then
 		CONFIG_PREFIX=$'testnet=1\n[test]'
-	elif [[ "${BITCOIN_NETWORK}" == "mainnet" ]]; then
-		CONFIG_PREFIX=$'mainnet=1\n[main]'
-	else 
+	elif [[ "${BITCOIN_NETWORK}" == "signet" ]]; then
+		CONFIG_PREFIX=$'signet=1\n[signet]'
+	else
+		# default: if no network specified, assume mainnet
+		CONFIG_PREFIX=$'[main]'
 		BITCOIN_NETWORK=""
 	fi
 


### PR DESCRIPTION
- Adds Bitcoin Core version 23.0
- Adds Bitcoin Core version 24.0

Dockerfiles based on existing Bitcoin Core version 22.0.
Both images built and tested locally on a x86_64 machine.
